### PR TITLE
ci: Replace PAT with GITHUB_TOKEN

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,5 +15,5 @@ jobs:
             ${{ runner.os }}-gems-
       - name: Build & Deploy to GitHub Pages
         uses: helaili/jekyll-action@v2
-        env:
-          JEKYLL_PAT: ${{ secrets.JEKYLL_PAT }}
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
There's been a release in the action used, which now supports the builtin GITHUB_TOKEN (no need to create a token yourself).

See https://github.com/marketplace/actions/jekyll-actions#use-the-action

The JEKYLL_PAT flow _deprecated_ and that's good because it is less secure and requires manual effort.
